### PR TITLE
remove numeric_only, fix max

### DIFF
--- a/examples/sat/bench_hillclimber.py
+++ b/examples/sat/bench_hillclimber.py
@@ -80,7 +80,7 @@ def hill_climb(k, r, seed, n, runs, dest, verbose, steep):
         n,
         n_runs=runs,
         rng=np.random.default_rng(seed=seed),
-        eps=10**-5,
+        error=10**-5,
         steep=steep,
     )
 
@@ -153,6 +153,8 @@ def plot(src, ref_path, ref_file, quantum_factor=2):
     """
     colors = {"QuBRA": "blue", "Cade": "orange"}
 
+    # TODO: this can stay the same
+
     def color_for_impl(impl):
         """
         Returns a color given a key. Does not duplicate colors so it might run
@@ -179,11 +181,14 @@ def plot(src, ref_path, ref_file, quantum_factor=2):
     reference = pd.read_json(ref_path, orient="split")
     history = pd.concat([history, reference])
 
+    # TODO: quantum cost calculator strategy
+
     # compute combined query costs of quantum search
     c = history["quantum_expected_classical_queries"]
     q = history["quantum_expected_quantum_queries"]
     history["quantum_cqq"] = c + quantum_factor * q
 
+    # TODO: line declaration
     # define lines to plot
     lines = {
         "classical_actual_queries": "Classical Queries",
@@ -191,9 +196,11 @@ def plot(src, ref_path, ref_file, quantum_factor=2):
     }
     seen_labels = []  # keep track to ensure proper legends
 
+    # TODO: group forming strategy
     # group plots by combinations of k and r
     groups = history.groupby(["k", "r"])
     # calculate the maximum value of the four relevant value columns
+    # TODO: relevant plottable values in strategy
     max_val_in_graph = (
         history[
             [
@@ -203,7 +210,7 @@ def plot(src, ref_path, ref_file, quantum_factor=2):
                 "quantum_expected_quantum_queries",
             ]
         ]
-        .max(numeric_only=True)
+        .max()
         .max()
     )
     # calculate the necessary exponent for the y-axis scaling
@@ -213,7 +220,9 @@ def plot(src, ref_path, ref_file, quantum_factor=2):
     if len(groups) == 1:
         axs = [axs]
     for ax, ((k, r), group) in zip(axs, groups):
+        # TODO: title uses global variables, also defined in strategy
         ax.set_title(f"k = {k}, r = {r}")
+        # TODO: the rest seams mostly universal, except for 'impl', maybe param 'alphanum columns' which are then excluded
         ax.set_xlim(10**2, 10**4)
         ax.set_ylim(300, 10**y_scale_exponent)
         ax.set_xscale("log")
@@ -223,10 +232,11 @@ def plot(src, ref_path, ref_file, quantum_factor=2):
         ax.grid(which="both")
 
         # group lines by implementation
+        # TODO: def need strategy impl here to, to define what we sort by and what we group by
         impls = group.groupby("impl")
         for name, impl in impls:
-            means = impl.groupby("n").mean(numeric_only=True)
-            errors = impl.groupby("n").sem(numeric_only=True)
+            means = impl.loc[:, impl.columns != "impl"].groupby("n").mean()
+            errors = impl.loc[:, impl.columns != "impl"].groupby("n").sem()
             for col, label in lines.items():
                 text = f"{label} ({name})"
                 if text in seen_labels:

--- a/examples/sat/hillclimber.py
+++ b/examples/sat/hillclimber.py
@@ -1,5 +1,4 @@
 """This module contains the hillclimber examples as seen in Cade et al.'s 2022 paper Grover beyond asymptotics."""
-
 from dataclasses import asdict
 from typing import Optional, Tuple, Callable
 import logging
@@ -67,10 +66,11 @@ def hill_climber(
         def pred(it: Tuple[Assignment, np.float_]) -> bool:
             return bool(it[1] > w)
 
+        def key_fun(it):
+            return list(it)[1]
+
         if steep:
-            result = max(
-                zip(neighbors, weights), key=lambda it: it[1], error=error, stats=stats
-            )
+            result = max(zip(neighbors, weights), key=key_fun, error=error, stats=stats)
             nx, nw = result
             if nw > w:
                 x, w = result
@@ -134,5 +134,5 @@ def run(
 
     # return pandas dataframe
     df = pd.DataFrame([list(row.values()) for row in history], columns=list(history[0]))
-    logging.info(df.groupby(["k", "r", "n"]).mean(numeric_only=True))
+    logging.info(df.loc[:, df.columns != "impl"].groupby(["k", "r", "n"]).mean())
     return df

--- a/examples/sat/test_hillclimber.py
+++ b/examples/sat/test_hillclimber.py
@@ -17,7 +17,12 @@ def test_maxsat_values_100(rng) -> None:
     history = hillclimber.run(
         3, 3, 100, n_runs=5, rng=rng, error=10**-5, random_weights=random_weights
     )
-    history = history.groupby(["k", "r", "n"]).mean(numeric_only=True).reset_index()
+    history = (
+        history.loc[:, history.columns != "impl"]
+        .groupby(["k", "r", "n"])
+        .mean()
+        .reset_index()
+    )
     stats = history.loc[0].to_dict()
 
     assert stats == {

--- a/qubrabench/algorithms/max.py
+++ b/qubrabench/algorithms/max.py
@@ -64,7 +64,7 @@ def max(
 
     max_elem_occurrences = 0
     for elem in iterable:
-        if key(elem) == max_elem:
+        if key(elem) == key(max_elem):
             max_elem_occurrences += 1
 
     if stats:


### PR DESCRIPTION
Hi, is this replacement of the numeric_only flag okay/correct in your mind? I'm not sure if I prefer the numeric_only approach or this approach to be honest, because it doesn't seem to change much in readability for me. I'd argue that it may even be easier to understand what is happening when numeric_only is used instead of just excluding a certain column - maybe a comment above the relevant lines would suffice to solve this issue. 

Apart from this implementation question, do you think we need the impl column at all? Tim and I don't think it is necessary any more, as long as we move the declaration of the implementation name (for the plotting) to a command line argument. So for instance when I pass the path to the reference data, I'd just pass another flag like -ref-name which would then name the values accordingly.

in theory.... 
closes #53