### PR TITLE
default tracking context

### DIFF
--- a/qubrabench/algorithms/amplitude.py
+++ b/qubrabench/algorithms/amplitude.py
@@ -3,11 +3,12 @@ import warnings
 import numpy as np
 import numpy.typing as npt
 
-from ..benchmark import BlockEncoding
+from ..benchmark import BlockEncoding, _qubrabench_method
 
 __all__ = ["estimate_amplitude"]
 
 
+@_qubrabench_method
 def estimate_amplitude(
     x: BlockEncoding,
     good_indices: npt.ArrayLike,

--- a/qubrabench/algorithms/max.py
+++ b/qubrabench/algorithms/max.py
@@ -12,6 +12,7 @@ from ..benchmark import (
     BenchmarkFrame,
     _already_benchmarked,
     _BenchmarkManager,
+    _qubrabench_method,
     track_queries,
 )
 from .search import cade_et_al_F
@@ -21,10 +22,11 @@ __all__ = ["max"]
 E = TypeVar("E")
 
 
+@_qubrabench_method
 def max(
     iterable: Iterable[E],
     *,
-    max_fail_probability: Optional[float] = None,
+    max_fail_probability: float,
     default: OptionalParameter[E] = _absent,
     key: Optional[Callable[[E], Any]] = None,
 ) -> E:
@@ -37,7 +39,6 @@ def max(
         max_fail_probability: upper bound on the failure probability of the quantum algorithm.
 
     Raises:
-        ValueError: Raised when the failure rate `error` is not provided and statistics cannot be calculated.
         ValueError: Raised when iterable is an empty sequence and no default is provided.
 
     Returns:
@@ -54,11 +55,6 @@ def max(
 
     # collect stats
     if is_benchmarking:
-        if max_fail_probability is None:
-            raise ValueError(
-                "max() parameter 'error' not provided, cannot compute quantum query statistics"
-            )
-
         N = 0
 
         sub_frames_access: list[BenchmarkFrame] = []

--- a/tests/algorithms/test_amplitude.py
+++ b/tests/algorithms/test_amplitude.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from qubrabench.algorithms.amplitude import estimate_amplitude
-from qubrabench.benchmark import track_queries
+from qubrabench.benchmark import default_tracker
 from qubrabench.datastructures.qndarray import state_preparation_unitary
 
 
@@ -10,13 +10,12 @@ def test_estimate_amplitude(rng):
     vector = rng.random(N)
     enc_vector = state_preparation_unitary(vector, eps=0)
 
-    with track_queries() as tracker:
-        actual_a = estimate_amplitude(
-            enc_vector, 0, precision=1e-5, max_fail_probability=2 / 3
-        )
-        expected_a = np.abs(vector[0] / np.linalg.norm(vector)) ** 2
+    actual_a = estimate_amplitude(
+        enc_vector, 0, precision=1e-5, max_fail_probability=2 / 3
+    )
+    expected_a = np.abs(vector[0] / np.linalg.norm(vector)) ** 2
 
-        np.testing.assert_allclose(actual_a, expected_a)
+    np.testing.assert_allclose(actual_a, expected_a)
 
-        stats = tracker.get_stats(enc_vector)
-        assert stats.quantum_expected_quantum_queries == 69116
+    stats = default_tracker().get_stats(enc_vector)
+    assert stats.quantum_expected_quantum_queries == 69116

--- a/tests/algorithms/test_linalg.py
+++ b/tests/algorithms/test_linalg.py
@@ -5,7 +5,7 @@ from qubrabench.algorithms.linalg import (
     qlsa_query_count_with_failure_probability,
     solve,
 )
-from qubrabench.benchmark import track_queries
+from qubrabench.benchmark import default_tracker
 from qubrabench.datastructures.qndarray import Qndarray
 
 
@@ -34,12 +34,12 @@ def test_solve_stats(rng):
         max_fail_probability=max_fail_probability,
         precision=precision,
     )
+    enc_y.access()
 
-    with track_queries() as tracker:
-        enc_y.access()
-        queries_y = tracker.get_stats(enc_y).quantum_expected_quantum_queries
-        queries_A = tracker.get_stats(A).quantum_expected_quantum_queries
-        queries_b = tracker.get_stats(b).quantum_expected_quantum_queries
+    tracker = default_tracker()
+    queries_y = tracker.get_stats(enc_y).quantum_expected_quantum_queries
+    queries_A = tracker.get_stats(A).quantum_expected_quantum_queries
+    queries_b = tracker.get_stats(b).quantum_expected_quantum_queries
 
     assert queries_y == 1
     expected_query_count_A = 2 * qlsa_query_count_with_failure_probability(

--- a/tests/algorithms/test_max.py
+++ b/tests/algorithms/test_max.py
@@ -5,7 +5,7 @@ import re
 import pytest
 
 from qubrabench.algorithms.max import max
-from qubrabench.benchmark import QueryStats, oracle, track_queries
+from qubrabench.benchmark import QueryStats, default_tracker, oracle
 
 
 def test_max_return_value():
@@ -25,35 +25,21 @@ def test_max_raises_on_empty_and_no_default():
         max([], max_fail_probability=10**-5)
 
 
-def test_max_raises_on_stats_requested_and_eps_missing():
-    """Tests that a Value error is raised by max if 'error' (failure rate) is not provided"""
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "max() parameter 'error' not provided, cannot compute quantum query statistics"
-        ),
-    ):
-        with track_queries():
-            max(range(100))
-
-
 def test_max_on_empty_with_default():
     assert max([], max_fail_probability=10**-5, default=42) == 42
 
 
 def test_max_stats():
-    with track_queries() as tracker:
+    @oracle
+    def key(x):
+        return -((x - 50) ** 2)
 
-        @oracle
-        def key(x):
-            return -((x - 50) ** 2)
+    result = max(range(100), key=key, max_fail_probability=10**-5)
+    assert result == 50
 
-        result = max(range(100), key=key, max_fail_probability=10**-5)
-        assert result == 50
-
-        assert tracker.get_stats(key) == QueryStats(
-            classical_actual_queries=100,
-            classical_expected_queries=100,
-            quantum_expected_classical_queries=0,
-            quantum_expected_quantum_queries=pytest.approx(1405.3368),
-        )
+    assert default_tracker().get_stats(key) == QueryStats(
+        classical_actual_queries=100,
+        classical_expected_queries=100,
+        quantum_expected_classical_queries=0,
+        quantum_expected_quantum_queries=pytest.approx(1405.3368),
+    )

--- a/tests/algorithms/test_search.py
+++ b/tests/algorithms/test_search.py
@@ -1,32 +1,27 @@
 """This module collects test functions for the qubrabench.search method."""
 
-import re
-
-import pytest
-
 from qubrabench.algorithms.search import search
-from qubrabench.benchmark import QueryStats, oracle, track_queries
+from qubrabench.benchmark import QueryStats, default_tracker, oracle
 
 
 def test_search_linear_scan():
     """Test linear search through a list"""
-    with track_queries() as tracker:
-        domain = range(0, 100)
+    domain = range(0, 100)
 
-        @oracle
-        def check(it):
-            return it == 50
+    @oracle
+    def check(it):
+        return it == 50
 
-        result = search(domain, check, max_fail_probability=10**-5)
-        assert result == 50
+    result = search(domain, check, max_fail_probability=10**-5)
+    assert result == 50
 
-        # test stats
-        assert tracker.get_stats(check) == QueryStats(
-            classical_actual_queries=51,
-            classical_expected_queries=51,
-            quantum_expected_classical_queries=72.9245740488006,
-            quantum_expected_quantum_queries=18.991528740664712,
-        )
+    # test stats
+    assert default_tracker().get_stats(check) == QueryStats(
+        classical_actual_queries=51,
+        classical_expected_queries=51,
+        quantum_expected_classical_queries=72.9245740488006,
+        quantum_expected_quantum_queries=18.991528740664712,
+    )
 
 
 def test_search_linear_scan_classical_queries(rng):
@@ -38,15 +33,12 @@ def test_search_linear_scan_classical_queries(rng):
         def check(it):
             return it == k
 
-        with track_queries() as tracker:
-            result = search(range(N), check, max_fail_probability=10**-5)
-            assert result == k
-            stats: QueryStats = tracker.get_stats(check)
-            assert (
-                stats.classical_actual_queries
-                == stats.classical_expected_queries
-                == k + 1
-            )
+        result = search(range(N), check, max_fail_probability=10**-5)
+        assert result == k
+        stats: QueryStats = default_tracker().get_stats(check)
+        assert (
+            stats.classical_actual_queries == stats.classical_expected_queries == k + 1
+        )
 
 
 def test_search_with_shuffle(rng):
@@ -55,39 +47,22 @@ def test_search_with_shuffle(rng):
     Args:
         rng (np.rng): Source of randomness provided by test fixtures
     """
-    with track_queries() as tracker:
-        domain = range(0, 100)
+    domain = range(0, 100)
 
-        @oracle
-        def check(it):
-            return it == 50
+    @oracle
+    def check(it):
+        return it == 50
 
-        result = search(domain, check, max_fail_probability=10**-5, rng=rng)
-        assert result == 50
+    result = search(domain, check, max_fail_probability=10**-5, rng=rng)
+    assert result == 50
 
-        # test stats
-        assert tracker.get_stats(check) == QueryStats(
-            classical_actual_queries=45,
-            classical_expected_queries=50.5,
-            quantum_expected_classical_queries=72.9245740488006,
-            quantum_expected_quantum_queries=18.991528740664712,
-        )
-
-
-def test_search_raises_on_stats_requested_and_eps_missing(rng):
-    """Test that a ValueError is thrown when 'error' (failure rate) is not provided to the search function.
-
-    Args:
-        rng (np.rng): Source of randomness provided by test fixtures
-    """
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "search() parameter 'error' not provided, cannot compute quantum query statistics"
-        ),
-    ):
-        with track_queries():
-            search(range(100), lambda it: it == 42, rng=rng)
+    # test stats
+    assert default_tracker().get_stats(check) == QueryStats(
+        classical_actual_queries=45,
+        classical_expected_queries=50.5,
+        quantum_expected_classical_queries=72.9245740488006,
+        quantum_expected_quantum_queries=18.991528740664712,
+    )
 
 
 def test_variable_time_key(rng):
@@ -98,13 +73,12 @@ def test_variable_time_key(rng):
                 return False
         return True
 
-    with track_queries() as tracker:
-        twin_primes = search(
-            range(2, 10),
-            key=lambda i: is_prime(i) and is_prime(i + 2),
-            rng=rng,
-            max_fail_probability=10**-5,
-        )
-        assert twin_primes == 3  # (3, 5)
-        stats = tracker.get_stats(is_prime)
-        print(stats)
+    twin_primes = search(
+        range(2, 10),
+        key=lambda i: is_prime(i) and is_prime(i + 2),
+        rng=rng,
+        max_fail_probability=10**-5,
+    )
+    assert twin_primes == 3  # (3, 5)
+    stats = default_tracker().get_stats(is_prime)
+    print(stats)

--- a/tests/datastructures/test_qndarray.py
+++ b/tests/datastructures/test_qndarray.py
@@ -10,13 +10,13 @@ def test_qndarray_iterate(rng):
         mat = rng.random(size=(N, M))
         qmat = Qndarray(mat)
 
-        with track_queries() as tracker:
+        with track_queries():
             mat_sum = 0
             for i in range(N):
                 for j in range(M):
                     mat_sum += qmat[i, j]
             np.testing.assert_allclose(mat_sum, np.sum(mat))
-            assert tracker.get_stats(qmat) == QueryStats(classical_actual_queries=N * M)
+            assert qmat.stats == QueryStats(classical_actual_queries=N * M)
 
             mat_max = 0
             for i in range(N):
@@ -24,9 +24,7 @@ def test_qndarray_iterate(rng):
                     mat_max = max(mat_max, qmat[i, j])
 
             np.testing.assert_allclose(mat_max, np.max(mat))
-            assert tracker.get_stats(qmat) == QueryStats(
-                classical_actual_queries=2 * N * M
-            )
+            assert qmat.stats == QueryStats(classical_actual_queries=2 * N * M)
 
 
 def test_qndarray_constructor_idempotent():
@@ -38,11 +36,9 @@ def test_qndarray_constructor_idempotent():
 def test_qndarray_view():
     a = Qndarray(np.eye(3))
     row = a[0, :]
-
-    with track_queries() as tracker:
-        _ = row[0]
-        assert tracker.get_stats(row) == QueryStats(classical_actual_queries=1)
-        assert tracker.get_stats(a) == QueryStats(classical_actual_queries=1)
+    _ = row[0]
+    assert row.stats == QueryStats(classical_actual_queries=1)
+    assert a.stats == QueryStats(classical_actual_queries=1)
 
 
 def test_qndarray_nested_views():
@@ -50,9 +46,8 @@ def test_qndarray_nested_views():
     b = a[:, :]
     row = b[0, :]
 
-    with track_queries() as tracker:
-        _ = row[0]
+    _ = row[0]
 
-        assert tracker.get_stats(row) == QueryStats(classical_actual_queries=1)
-        assert tracker.get_stats(a) == QueryStats(classical_actual_queries=1)
-        assert tracker.get_stats(b) == QueryStats(classical_actual_queries=1)
+    assert row.stats == QueryStats(classical_actual_queries=1)
+    assert a.stats == QueryStats(classical_actual_queries=1)
+    assert b.stats == QueryStats(classical_actual_queries=1)


### PR DESCRIPTION
Always track queries if a qubrabench subroutine is called. 

This now forces `max_fail_probability` to be a mandatory argument. Previously, if `max_fail_probability is None`, then we just run the classical emulation without tracking, which is no longer valid.